### PR TITLE
fix: quote 3.0 in CI configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: [
-          3.0,
+          "3.0",
           # 3.1,
         ]
         gemfile: [


### PR DESCRIPTION

### Description 📖

This pull request quotes the 3.0 in the CI configuration.  An unquoted 3.0 is truncated to a 3, and loads the latest Ruby 3 version - at this time Ruby 3.1.2.  This seems contrary to the intention.

There is a commented out "3.1", so I'm not sure if this behavior is intentional.  If there's a desired to run exclusively with the latest Ruby 3 version, I'd suggest that the ambiguous 3.0 be replaced with a 3.  Otherwise it might be desirable to uncomment the 3.1, since it runs fine.

### Background 📜

This was happening because an unquoted 3.0 is truncated to 3.

### The Fix 🔨

By changing the unquoted 3.0 to a quoted 3.0, this expected Ruby version is loaded for this matrix element.

### Screenshots 📷

Here's a screenshot of a recent run showing the truncation and loading of Ruby 3.1.2:

<img width="1548" alt="Screen Shot 2022-07-13 at 10 27 31 AM" src="https://user-images.githubusercontent.com/421488/178760079-3dde3133-6f4c-4842-b88c-f4912aaa0e38.png">


