### PR TITLE
feat: map citext from PostgreSQL to string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
         run: bin/rspec
 
       - name: Upload code coverage to Code Climate
+        if: ${{ contains(github.ref, 'main') }}
         run: |
           export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
           ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}

--- a/spec/types_from_serializers/generator_spec.rb
+++ b/spec/types_from_serializers/generator_spec.rb
@@ -79,4 +79,14 @@ describe "Generator" do
     expect_generator.to generate_serializers.exactly(serializers.size).times
     expect { Rake::Task["types_from_serializers:generate"].invoke }.not_to raise_error
   end
+
+  describe "types mapping" do
+    it "maps citext type from SQL to string type in TypeScript" do
+      db_type = :citext
+
+      ts_type = TypesFromSerializers.config.sql_to_typescript_type_mapping[db_type]
+
+      expect(ts_type).to eq(:string)
+    end
+  end
 end

--- a/types_from_serializers/lib/types_from_serializers/generator.rb
+++ b/types_from_serializers/lib/types_from_serializers/generator.rb
@@ -380,6 +380,7 @@ module TypesFromSerializers
           integer: :number,
           string: :string,
           text: :string,
+          citext: :string,
         }.tap do |types|
           types.default = :unknown
         end,


### PR DESCRIPTION
### Description 📖

Map `citext` type from PostgreSQL to `string` type in TypeScript.

### Background 📜

`citext` is case-insensitive character string type in PostgreSQL. It's often used for unique fields where case sensitivity should be ignored, like email, repo name, etc. Supporting this mapping by default would make it easier to integrate this library in a codebase that is using `citext`.

I wanted to add a spec that tests the behaviour through `Property#infer_type_from` but the current test suite is not very friendly in this aspect 😅

### The Fix 🔨

By addin default mapping from `citext` to `string`, developers won't have to extend the gem's config only to support this mapping in their app.
