### PR TITLE
Remove pry-byebug gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,8 +35,6 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     builder (3.2.4)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
@@ -68,12 +66,6 @@ GEM
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-test (2.0.2)
@@ -161,7 +153,6 @@ DEPENDENCIES
   bundler (~> 2)
   js_from_routes
   oj_serializers
-  pry-byebug (~> 3.9)
   rake (~> 13)
   rspec-given (~> 3.8)
   rspec-snapshot

--- a/playground/vanilla/Gemfile
+++ b/playground/vanilla/Gemfile
@@ -26,7 +26,6 @@ gem "inertia_rails", ">= 1.2.2"
 
 group :development, :test do
   gem "listen", "~> 3.7"
-  gem "pry-byebug"
   gem "rspec-rails"
   gem "rails-controller-testing"
 end

--- a/playground/vanilla/Gemfile.lock
+++ b/playground/vanilla/Gemfile.lock
@@ -65,8 +65,6 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     diff-lcs (1.5.0)
@@ -101,12 +99,6 @@ GEM
     oj (3.14.2)
     oj_serializers (2.0.2)
       oj (>= 3.14.0)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -198,7 +190,6 @@ DEPENDENCIES
   js_from_routes (~> 2.0.6)
   listen (~> 3.7)
   oj_serializers
-  pry-byebug
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-controller-testing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,5 @@ require "rails"
 require "oj_serializers"
 require "types_from_serializers"
 require "rspec/given"
-require "pry-byebug"
 
 $LOAD_PATH.push File.expand_path("../playground", __dir__)

--- a/types_from_serializers/types_from_serializers.gemspec
+++ b/types_from_serializers/types_from_serializers.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency "listen", "~> 3.2"
 
   s.add_development_dependency "bundler", "~> 2"
-  s.add_development_dependency "pry-byebug", "~> 3.9"
   s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "rspec-given", "~> 3.8"
   s.add_development_dependency "rspec-snapshot"


### PR DESCRIPTION
### Description 📖

Remove `pry-byebug` gem.

### Background 📜

The `pry-byebug` gem dependency is causing an exception when running the test suit. This is most likely due to new Ruby version. Unfortunately, there is no recent updates in the gem and it doesn't seem like a fix would be applied there.

The dependency is not used directly and my guess is that it's there mainly for debugging purposes. I would propose to drop this dependency and use the built-in `binding.irb` for debugging.

https://ruby-doc.org/stdlib-2.7.0/libdoc/irb/rdoc/Binding.html

### The Fix 🔨

By removing the dependency, we can run the test suite without any errors.

Before:

```
❯ bin/rspec

An error occurred while loading spec_helper.
Failure/Error: require "pry-byebug"

NameError:
  undefined method `=~' for class `Pry::Code'
No examples found.

Finished in 0.00002 seconds (files took 0.24819 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

After:

```
❯ bin/rspec
.Generating TypeScript interfaces...completed in 0.0 seconds.
Found 9 serializers:
        ComposerSerializer
        ComposerWithSongsSerializer
        ModelSerializer
        Nested::AlbumSerializer
        SnakeComposerSerializer
        SongSerializer
        SongWithVideosSerializer
        VideoSerializer
        VideoWithSongSerializer
.

Finished in 0.15912 seconds (files took 1.01 seconds to load)
2 examples, 0 failures
```
