### PR TITLE
feat: convert uuid fields to string type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ bundle install
 pnpm install
 ```
 
+```
+pnpm migrate
+```
+
 ## Making sure your changes pass all tests
 
 There are a number of automated checks which run on GitHub Actions when a pull request is created.
@@ -24,11 +28,13 @@ pnpm lint
 ```
 
 ### 2. Check the code for Ruby style violations
+
 ```
 bin/rubocop
 ```
 
 ### 3. Run the test suite
+
 ```
 bin/rspec
 ```

--- a/spec/types_from_serializers/generator_spec.rb
+++ b/spec/types_from_serializers/generator_spec.rb
@@ -115,5 +115,13 @@ describe "Generator" do
 
       expect(ts_type).to eq(:string)
     end
+
+    it "maps uuid type from SQL to string type in TypeScript" do
+      db_type = :uuid
+
+      ts_type = TypesFromSerializers.config.sql_to_typescript_type_mapping[db_type]
+
+      expect(ts_type).to eq(:string)
+    end
   end
 end

--- a/types_from_serializers/lib/types_from_serializers/generator.rb
+++ b/types_from_serializers/lib/types_from_serializers/generator.rb
@@ -392,6 +392,7 @@ module TypesFromSerializers
           string: :string,
           text: :string,
           citext: :string,
+          uuid: :string,
         }.tap do |types|
           types.default = :unknown
         end,


### PR DESCRIPTION
This pull request adds support for UUID fields, converting them to strings in the TypeScript types.

I also added an entry to the CONTRIBUTING.md file, because I was not able to run rspec until I ran `pnpm migrate` to set up the database.