### PR TITLE
feat: add support for json and jsonb fields

### DIFF
--- a/spec/types_from_serializers/generator_spec.rb
+++ b/spec/types_from_serializers/generator_spec.rb
@@ -115,5 +115,21 @@ describe "Generator" do
 
       expect(ts_type).to eq(:string)
     end
+
+    it "maps json type from SQL to object type in TypeScript" do
+      db_type = :json
+
+      ts_type = TypesFromSerializers.config.sql_to_typescript_type_mapping[db_type]
+
+      expect(ts_type).to eq("Record<string, any>")
+    end
+
+    it "maps jsonb type from SQL to object type in TypeScript" do
+      db_type = :jsonb
+
+      ts_type = TypesFromSerializers.config.sql_to_typescript_type_mapping[db_type]
+
+      expect(ts_type).to eq("Record<string, any>")
+    end
   end
 end

--- a/types_from_serializers/lib/types_from_serializers/generator.rb
+++ b/types_from_serializers/lib/types_from_serializers/generator.rb
@@ -392,6 +392,8 @@ module TypesFromSerializers
           string: :string,
           text: :string,
           citext: :string,
+          json: "Record<string, any>",
+          jsonb: "Record<string, any>",
         }.tap do |types|
           types.default = :unknown
         end,


### PR DESCRIPTION
This pull request adds support for json and jsonb fields, converting them to `Record<string, any>` in the Typescript types.

This might be worth a discussion, since Typescript conventions would dictate that a more appropriate type is `Record<string, unknown>`, given that `any` is seen as a code smell. However, making it `Record<string, unknown>` would have the effect of forcing you to override the library's type conversion, by either specifying `Record<string, any>` or by writing a more comprehensive type, which defeats the purpose of automatic conversion.

A stronger alternative would be something like `JSONObject`:

```
type JSONValue = 
  | string
  | number
  | boolean
  | null
  | JSONValue[]
  | { [key: string]: JSONValue };

type JSONObject = { [key: string]: JSONValue };
```

But that seems like a fairly large departure from the current approach of fairly straightforward type conversion.